### PR TITLE
fix: nginx

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -19,21 +19,23 @@ server {
     server_name backend.radif.ru;
 
 # Подключаю сертификаты, которые получил в центре сертификации - Let's Encrypt
-    ssl_certificate /etc/letsencrypt/live/backend.radif.ru/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/backend.radif.ru/privkey.pem;
-    ssl_trusted_certificate /etc/letsencrypt/live/backend.radif.ru/chain.pem;
+    ssl_certificate /etc/letsencrypt/live/radif.ru/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/radif.ru/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/radif.ru/chain.pem;
+
     ssl_stapling on;
     ssl_stapling_verify on;
-#    resolver 127.0.0.1 8.8.8.8;
 
 # Перенаправление схемы запросов в https
-#     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $scheme;
 
 # Исключаю возврат на http-версию сайта
-#     add_header Strict-Transport-Security "max-age=31536000";
+    add_header Strict-Transport-Security "max-age=31536000";
 
 # Явно "ломаю" все картинки с http://
     add_header Content-Security-Policy "img-src https: data:; upgrade-insecure-requests";
+
+    location = /favicon.ico { access_log off; log_not_found off; }
 
     location / {
 # Перенаправляю все запросы в сервис бэкенда, к Gunicorn, запущенному на порту 3333


### PR DESCRIPTION
Исправил путь к ssl сертификатам для Nginx, теперь для удобства использую общий сертификат для всех доменов и поддоменов (расположены в вышестоящем репозитории "www" и пробрасываются во вложенные docker контейнеры)